### PR TITLE
Replace literal format strings with static constants

### DIFF
--- a/timers/src/main/java/com/langtoun/timers/NanoTimer.java
+++ b/timers/src/main/java/com/langtoun/timers/NanoTimer.java
@@ -330,7 +330,7 @@ public final class NanoTimer {
   public String splitTimeWithName(final int index, final TimeUnit timeUnit) {
     if (timerState == NanoTimerState.STOPPED) {
       if (index < 0 || index >= splits.size() - 1) {
-        throw new IllegalArgumentException(String.format("split time index %d out of range: 0 < index <= %d", index, splits.size() - 1));
+        throw new IllegalArgumentException(String.format(TIMER_SPLIT_OUT_OF_RANGE, index, splits.size() - 1));
       }
       return String.format(TIMER_SPLIT_WITH_NAME, splits.get(index).getName(), timeUnit.convert(splitTimes()[index], TimeUnit.NANOSECONDS), timeUnit.name().toLowerCase(Locale.ENGLISH));
     } else {
@@ -426,7 +426,7 @@ public final class NanoTimer {
   public String splitPeriodWithName(final int index, final TimeUnit timeUnit) {
     if (timerState == NanoTimerState.STOPPED) {
       if (index < 0 || index >= splits.size() - 1) {
-        throw new IllegalArgumentException(String.format("split period index %d out of range: 0 < index <= %d", index, splits.size() - 1));
+        throw new IllegalArgumentException(String.format(TIMER_SPLIT_OUT_OF_RANGE, index, splits.size() - 1));
       }
       return String.format(TIMER_SPLIT_WITH_NAME, splits.get(index).getName(), timeUnit.convert(splitPeriods()[index], TimeUnit.NANOSECONDS), timeUnit.name().toLowerCase(Locale.ENGLISH));
     } else {


### PR DESCRIPTION
Two format strings used to create exception messages were still using string literals instead of the static constants that were being used elsewhere. This change brings them in line with other methods in the class.